### PR TITLE
Fix dashboard available shifts card and remove upcoming

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,8 +3,10 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, Clock, Users } from 'lucide-react';
+import { CheckCircle, Users } from 'lucide-react';
 import Link from 'next/link';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 
 interface User {
   name: string;
@@ -14,13 +16,167 @@ interface User {
 
 export default function DashboardPage() {
   const [user, setUser] = useState<User | null>(null);
+  const [scheduleStats, setScheduleStats] = useState({
+    totalSlots: 0,
+    filledSlots: 0,
+    availableSlots: 0,
+    thisMonthUsers: 0,
+  });
 
   useEffect(() => {
     const userData = localStorage.getItem('user');
     if (userData) {
       setUser(JSON.parse(userData));
     }
+    
+    calculateScheduleStats();
+    
+    // Set up real-time listener for schedule changes
+    const currentDate = new Date();
+    const currentMonth = currentDate.getMonth(); // 0-indexed for schedule ID
+    const currentYear = currentDate.getFullYear();
+    const scheduleId = `${currentYear}-${currentMonth}`;
+    const scheduleRef = doc(db, 'schedules', scheduleId);
+    
+    const unsubscribe = onSnapshot(scheduleRef, () => {
+      // Recalculate stats when schedule changes
+      calculateScheduleStats();
+    }, (error) => {
+      console.error('Error listening to schedule changes:', error);
+    });
+
+    return () => {
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
   }, []);
+
+  const calculateScheduleStats = async () => {
+    try {
+      const currentDate = new Date();
+      const currentMonth = currentDate.getMonth(); // Keep 0-indexed for API consistency
+      const currentYear = currentDate.getFullYear();
+      
+      // Calculate remaining WEEKDAYS in the current month (from today onwards, excluding weekends)
+      const today = currentDate.getDate();
+      const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
+      
+      let remainingWeekdays = 0;
+      for (let day = today; day <= daysInMonth; day++) {
+        const date = new Date(currentYear, currentMonth, day);
+        const dayOfWeek = date.getDay();
+        // Skip weekends (0 = Sunday, 6 = Saturday)
+        if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+          remainingWeekdays++;
+        }
+      }
+      
+      const maxPossibleSlots = remainingWeekdays * 4; // 2 morning + 2 afternoon slots per weekday
+      
+      // Fetch current month's schedule
+      const response = await fetch(`/api/schedule?month=${currentMonth}&year=${currentYear}`);
+      if (!response.ok) {
+        // If no schedule exists, show all slots as available
+        setScheduleStats({
+          totalSlots: maxPossibleSlots,
+          filledSlots: 0,
+          availableSlots: maxPossibleSlots,
+          thisMonthUsers: 0,
+        });
+        return;
+      }
+      
+      const data = await response.json();
+      const schedule = data.schedule || data || [];
+      
+      // Ensure schedule is an array and check if empty
+      if (!Array.isArray(schedule) || schedule.length === 0) {
+        setScheduleStats({
+          totalSlots: maxPossibleSlots,
+          filledSlots: 0,
+          availableSlots: maxPossibleSlots,
+          thisMonthUsers: 0,
+        });
+        return;
+      }
+      
+      // Calculate actual statistics from existing schedule (only from today onwards)
+      let filledSlots = 0;
+      const uniqueOfficers = new Set<string>();
+      
+      schedule.forEach((day: { 
+        id: string; 
+        date: Date | string; 
+        morningSlot?: { officers?: { name: string }[]; maxOfficers?: number }; 
+        afternoonSlot?: { officers?: { name: string }[]; maxOfficers?: number } 
+      }) => {
+        // Only count days from today onwards
+        let dayOfMonth;
+        
+        if (day.date instanceof Date) {
+          dayOfMonth = day.date.getDate();
+        } else if (typeof day.date === 'string') {
+          dayOfMonth = new Date(day.date).getDate();
+        } else {
+          // Fallback: assume it's a day number or use day ID
+          dayOfMonth = parseInt(day.id) || 1;
+        }
+        
+        if (dayOfMonth >= today) {
+          const morningOfficers = day.morningSlot?.officers || [];
+          const afternoonOfficers = day.afternoonSlot?.officers || [];
+          
+          // Count filled slots
+          filledSlots += morningOfficers.length + afternoonOfficers.length;
+          
+          // Track unique officers
+          [...morningOfficers, ...afternoonOfficers].forEach((officer: { name: string } | string) => {
+            if (officer && typeof officer === 'object' && officer.name) {
+              uniqueOfficers.add(officer.name);
+            } else if (officer && typeof officer === 'string') {
+              uniqueOfficers.add(officer);
+            }
+          });
+        }
+      });
+      
+      const availableSlots = maxPossibleSlots - filledSlots;
+      
+      setScheduleStats({
+        totalSlots: maxPossibleSlots,
+        filledSlots,
+        availableSlots,
+        thisMonthUsers: uniqueOfficers.size,
+      });
+    } catch (error) {
+      console.error('Error calculating schedule stats:', error);
+      // Fallback: calculate based on remaining weekdays in current month
+      const currentDate = new Date();
+      const currentMonth = currentDate.getMonth();
+      const currentYear = currentDate.getFullYear();
+      const today = currentDate.getDate();
+      const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
+      
+      let remainingWeekdays = 0;
+      for (let day = today; day <= daysInMonth; day++) {
+        const date = new Date(currentYear, currentMonth, day);
+        const dayOfWeek = date.getDay();
+        if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+          remainingWeekdays++;
+        }
+      }
+      
+      const maxPossibleSlots = remainingWeekdays * 4;
+      
+      setScheduleStats({
+        totalSlots: maxPossibleSlots,
+        filledSlots: 0,
+        availableSlots: maxPossibleSlots,
+        thisMonthUsers: 0,
+      });
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -37,29 +193,16 @@ export default function DashboardPage() {
         </CardContent>
       </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-base font-medium">Available Shifts</CardTitle>
-            <Calendar className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">12</div>
-            <p className="text-xs text-muted-foreground">This month</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-base font-medium">Upcoming Shift</CardTitle>
-            <Clock className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-lg font-bold">Tomorrow</div>
-            <p className="text-xs text-muted-foreground mt-1">8:00 AM - 4:00 PM</p>
-          </CardContent>
-        </Card>
-      </div>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-base font-medium">Available Shifts</CardTitle>
+          <CheckCircle className="h-4 w-4 text-green-600" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold text-green-600">{scheduleStats.availableSlots} remaining</div>
+          <p className="text-xs text-muted-foreground">Open for signup</p>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>


### PR DESCRIPTION
Update dashboard's 'Available Shifts' card for real-time accuracy and remove the 'Upcoming Shift' card.

The previous 'Available Shifts' card displayed static data. This change implements dynamic calculation of available shifts based on the current month's remaining weekdays and real-time schedule updates, mirroring the functionality of the admin page's 'Available Slots' card, and adds 'remaining' text to the display.

---
<a href="https://cursor.com/background-agent?bcId=bc-86afc425-5ef4-4025-8b1e-233200e53d43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86afc425-5ef4-4025-8b1e-233200e53d43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

