### PR TITLE
UI/UX improvements: schedule feedback, navbar redesign, animated login

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import ProtectedRoute from '@/components/auth/protected-route';
+import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { ChangelogDialog } from '@/components/ui/changelog-dialog';
 import {
@@ -28,6 +29,10 @@ import {
   X,
   ChevronDown,
 } from 'lucide-react';
+
+// The navbar stays navy in both themes, so nav text must stay literal white;
+// theme-aware tokens would flip it dark in light mode
+const navFocusRing = 'focus-visible:ring-white/60 focus-visible:ring-offset-0';
 
 export default function DashboardLayout({
   children,
@@ -92,18 +97,20 @@ export default function DashboardLayout({
               {/* Brand */}
               <Link
                 href="/dashboard"
-                className="flex min-w-0 items-center gap-2.5 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                className={cn(
+                  'flex min-w-0 items-center gap-2.5 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60'
+                )}
               >
                 <Image
                   src="/logo-cool.png"
                   alt="Cheverly Police Department"
-                  width={40}
-                  height={40}
+                  width={48}
+                  height={48}
                   quality={100}
                   priority
-                  className="h-9 w-9 rounded-md object-contain md:h-10 md:w-10"
+                  className="h-11 w-11 rounded-md object-contain md:h-12 md:w-12"
                 />
-                <span className="truncate text-base font-bold text-navbar-foreground sm:text-lg">
+                <span className="truncate text-base font-bold text-white sm:text-lg">
                   <span className="hidden lg:inline">Cheverly PD Metro</span>
                   <span className="lg:hidden">Cheverly PD</span>
                 </span>
@@ -112,19 +119,20 @@ export default function DashboardLayout({
               {/* Desktop navigation */}
               <div className="hidden flex-1 items-center gap-1 md:ml-6 md:flex">
                 {primaryLinks.map((item) => (
-                  <Link
+                  <Button
                     key={item.href}
-                    href={item.href}
+                    asChild
+                    variant="ghost"
                     className={cn(
-                      'rounded-full px-4 py-2 text-sm font-medium transition-colors duration-200',
-                      'text-navbar-foreground/75 hover:bg-white/10 hover:text-white',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
+                      'rounded-full px-4 text-white/75 hover:bg-white/10 hover:text-white',
+                      navFocusRing,
                       isActive(item.href) && 'bg-white/15 text-white'
                     )}
-                    aria-current={isActive(item.href) ? 'page' : undefined}
                   >
-                    {item.label}
-                  </Link>
+                    <Link href={item.href} aria-current={isActive(item.href) ? 'page' : undefined}>
+                      {item.label}
+                    </Link>
+                  </Button>
                 ))}
               </div>
 
@@ -134,21 +142,22 @@ export default function DashboardLayout({
                 <ThemeToggle />
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <button
+                    <Button
+                      variant="ghost"
                       className={cn(
-                        'flex items-center gap-2 rounded-full p-1 pr-2 transition-colors duration-200',
-                        'hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60'
+                        'h-auto gap-2 rounded-full p-1 pr-2 text-white hover:bg-white/10 hover:text-white',
+                        navFocusRing
                       )}
                       aria-label="Account menu"
                     >
                       <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/15 text-xs font-semibold text-white">
                         {initials}
                       </span>
-                      <span className="hidden max-w-[160px] truncate text-sm font-medium text-navbar-foreground lg:block">
+                      <span className="hidden max-w-[160px] truncate text-sm font-medium lg:block">
                         {displayName}
                       </span>
-                      <ChevronDown className="h-4 w-4 text-navbar-foreground/70" aria-hidden="true" />
-                    </button>
+                      <ChevronDown className="h-4 w-4 text-white/70" aria-hidden="true" />
+                    </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-56">
                     <DropdownMenuLabel className="font-normal">
@@ -182,11 +191,13 @@ export default function DashboardLayout({
               <div className="flex items-center gap-1 md:hidden">
                 <ChangelogDialog />
                 <ThemeToggle />
-                <button
+                <Button
+                  variant="ghost"
+                  size="icon"
                   onClick={() => setMenuOpen(!menuOpen)}
                   className={cn(
-                    'flex h-11 w-11 items-center justify-center rounded-full text-navbar-foreground transition-colors duration-200',
-                    'hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60'
+                    'h-11 w-11 rounded-full text-white hover:bg-white/10 hover:text-white',
+                    navFocusRing
                   )}
                   aria-label={menuOpen ? 'Close menu' : 'Open menu'}
                   aria-expanded={menuOpen}
@@ -197,7 +208,7 @@ export default function DashboardLayout({
                   ) : (
                     <Menu className="h-6 w-6" aria-hidden="true" />
                   )}
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -210,21 +221,26 @@ export default function DashboardLayout({
             >
               <div className="space-y-1 px-3 pb-4 pt-3">
                 {[...primaryLinks, ...accountLinks].map((item) => (
-                  <Link
+                  <Button
                     key={item.href}
-                    href={item.href}
+                    asChild
+                    variant="ghost"
                     className={cn(
-                      'flex items-center gap-3 rounded-lg px-3 py-3 text-base font-medium transition-colors duration-200',
-                      'text-navbar-foreground/80 hover:bg-white/10 hover:text-white active:bg-white/15',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
+                      'h-auto w-full justify-start gap-3 rounded-lg px-3 py-3 text-base font-medium',
+                      'text-white/80 hover:bg-white/10 hover:text-white active:bg-white/15',
+                      navFocusRing,
                       isActive(item.href) && 'bg-white/15 text-white'
                     )}
-                    onClick={() => setMenuOpen(false)}
-                    aria-current={isActive(item.href) ? 'page' : undefined}
                   >
-                    <item.icon className="h-5 w-5" aria-hidden="true" />
-                    {item.label}
-                  </Link>
+                    <Link
+                      href={item.href}
+                      onClick={() => setMenuOpen(false)}
+                      aria-current={isActive(item.href) ? 'page' : undefined}
+                    >
+                      <item.icon className="h-5 w-5" aria-hidden="true" />
+                      {item.label}
+                    </Link>
+                  </Button>
                 ))}
                 <div className="mt-3 border-t border-white/10 pt-3">
                   <div className="flex items-center gap-3 px-3 py-2">
@@ -234,21 +250,22 @@ export default function DashboardLayout({
                     <div className="min-w-0">
                       <div className="truncate text-sm font-medium text-white">{displayName}</div>
                       {user?.email && (
-                        <div className="truncate text-xs text-navbar-foreground/60">{user.email}</div>
+                        <div className="truncate text-xs text-white/60">{user.email}</div>
                       )}
                     </div>
                   </div>
-                  <button
+                  <Button
+                    variant="ghost"
                     onClick={handleLogout}
                     className={cn(
-                      'flex w-full items-center gap-3 rounded-lg px-3 py-3 text-base font-medium transition-colors duration-200',
-                      'text-red-300 hover:bg-white/10 active:bg-white/15',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60'
+                      'h-auto w-full justify-start gap-3 rounded-lg px-3 py-3 text-base font-medium',
+                      'text-red-300 hover:bg-white/10 hover:text-red-200 active:bg-white/15',
+                      navFocusRing
                     )}
                   >
                     <LogOut className="h-5 w-5" aria-hidden="true" />
                     Logout
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -11,7 +11,12 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { toast } from 'sonner';
 import { signInWithEmailAndPassword, onAuthStateChanged } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
-import { Eye, EyeOff, ShieldCheck, AlertTriangle } from 'lucide-react';
+import { Eye, EyeOff, ShieldCheck, AlertTriangle, Loader2 } from 'lucide-react';
+
+// Staggered entrance for landing content; honors prefers-reduced-motion.
+// Delays are set inline because Tailwind can't see runtime-built class names.
+const entrance =
+  'animate-in fade-in slide-in-from-bottom-4 duration-700 fill-mode-backwards motion-reduce:animate-none';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -155,9 +160,13 @@ export default function LoginPage() {
       <div className="fixed inset-0 lg:hidden -z-10 bg-background">
         {/* Gradient overlay - adapts to theme */}
         <div className="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-emerald-500/5 dark:from-primary/10 dark:via-transparent dark:to-emerald-500/10" />
-        {/* Geometric accent shapes */}
-        <div className="absolute top-0 right-0 w-72 h-72 bg-primary/10 dark:bg-primary/20 rounded-full blur-3xl transform translate-x-1/3 -translate-y-1/3" />
-        <div className="absolute bottom-0 left-0 w-80 h-80 bg-emerald-500/5 dark:bg-emerald-500/10 rounded-full blur-3xl transform -translate-x-1/3 translate-y-1/3" />
+        {/* Geometric accent shapes, drifting slowly. Positioned with inset
+            offsets (not translate) so the float animation owns transform */}
+        <div className="absolute -top-24 -right-24 w-72 h-72 bg-primary/10 dark:bg-primary/20 rounded-full blur-3xl animate-float motion-reduce:animate-none" />
+        <div
+          className="absolute -bottom-28 -left-28 w-80 h-80 bg-emerald-500/5 dark:bg-emerald-500/10 rounded-full blur-3xl animate-float motion-reduce:animate-none"
+          style={{ animationDuration: '14s', animationDelay: '2s' }}
+        />
         {/* Subtle dot pattern */}
         <div className="absolute inset-0 opacity-[0.03] dark:opacity-[0.05]" style={{
           backgroundImage: `radial-gradient(circle, currentColor 1px, transparent 1px)`,
@@ -166,7 +175,7 @@ export default function LoginPage() {
       </div>
 
       {/* Desktop left panel - hidden on mobile */}
-      <div className="relative hidden lg:flex flex-col justify-between overflow-hidden bg-gradient-to-br from-slate-950 via-primary to-slate-900 p-10 text-white">
+      <div className="relative hidden lg:flex flex-col justify-between overflow-hidden bg-gradient-to-br from-slate-950 via-primary to-slate-900 bg-[length:200%_200%] animate-gradient-pan motion-reduce:animate-none p-10 text-white">
         <div className="absolute inset-0 opacity-20">
           <Image
             src="/logo-cool.png"
@@ -177,44 +186,54 @@ export default function LoginPage() {
             priority
           />
         </div>
+        {/* Ambient glow accents */}
+        <div className="absolute -top-32 -left-32 h-96 w-96 rounded-full bg-white/10 blur-3xl animate-float motion-reduce:animate-none" aria-hidden />
+        <div
+          className="absolute -bottom-40 -right-24 h-96 w-96 rounded-full bg-emerald-400/10 blur-3xl animate-float motion-reduce:animate-none"
+          style={{ animationDuration: '16s', animationDelay: '3s' }}
+          aria-hidden
+        />
         <div className="relative z-10 space-y-6">
-          <div className="inline-flex items-center gap-3 rounded-full bg-white/10 px-4 py-2 text-sm uppercase tracking-wide">
+          <div className={`inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm uppercase tracking-wide backdrop-blur ${entrance}`}>
             <ShieldCheck className="h-5 w-5 text-emerald-300" />
             Cheverly PD Metro Detail
           </div>
-          <div>
-            <h1 className="text-3xl font-bold leading-tight">Protecting The Line Starts With A Solid Schedule</h1>
+          <div className={entrance} style={{ animationDelay: '120ms' }}>
+            <h1 className="text-3xl font-bold leading-tight xl:text-4xl">Protecting The Line Starts With A Solid Schedule</h1>
             <p className="mt-3 max-w-md text-white/80">
               Review coverage, lock in overtime, and keep your team coordinated with real-time updates from HQ.
             </p>
           </div>
           <ul className="space-y-3 text-white/80">
-            <li className="flex items-start gap-3">
+            <li className={`flex items-start gap-3 ${entrance}`} style={{ animationDelay: '240ms' }}>
               <span className="mt-1 h-2 w-2 rounded-full bg-emerald-300" aria-hidden />
               Secure access backed by Firebase authentication
             </li>
-            <li className="flex items-start gap-3">
+            <li className={`flex items-start gap-3 ${entrance}`} style={{ animationDelay: '320ms' }}>
               <span className="mt-1 h-2 w-2 rounded-full bg-emerald-300" aria-hidden />
               Live schedule sync so every shift stays covered
             </li>
           </ul>
         </div>
-        <div className="relative z-10 text-sm text-white/70">
-          Need help? Email <a href="mailto:obiler@cheverlypolice.org" className="underline">obiler@cheverlypolice.org</a>
+        <div className={`relative z-10 text-sm text-white/70 ${entrance}`} style={{ animationDelay: '400ms' }}>
+          Need help? Email <a href="mailto:obiler@cheverlypolice.org" className="underline transition-colors hover:text-white">obiler@cheverlypolice.org</a>
         </div>
       </div>
 
       {/* Login form panel */}
       <div className="flex flex-col items-center justify-center p-6 sm:p-10">
         {/* Mobile header - visible only on small screens */}
-        <div className="lg:hidden mb-6 text-center">
-          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 dark:bg-primary/20 border border-primary/20 dark:border-primary/30 px-4 py-2 text-sm uppercase tracking-wide text-primary dark:text-primary-foreground">
+        <div className={`lg:hidden mb-6 text-center ${entrance}`}>
+          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 dark:bg-primary/20 border border-primary/20 dark:border-primary/30 px-4 py-2 text-sm uppercase tracking-wide text-primary dark:text-primary-foreground backdrop-blur">
             <ShieldCheck className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
             <span className="font-medium">Cheverly PD</span>
           </div>
         </div>
 
-        <Card className="w-full max-w-md shadow-xl">
+        <Card
+          className={`w-full max-w-md border-border/60 bg-card/80 shadow-2xl backdrop-blur-xl ${entrance}`}
+          style={{ animationDelay: '150ms' }}
+        >
           <CardHeader className="space-y-1 text-center">
             <CardTitle className="text-2xl font-bold">Cheverly PD Metro Portal</CardTitle>
             <CardDescription>
@@ -260,7 +279,7 @@ export default function LoginPage() {
                   </button>
                 </div>
                 {capsLockOn && (
-                  <div className="flex items-center gap-2 text-xs font-medium text-amber-600">
+                  <div className="flex items-center gap-2 text-xs font-medium text-amber-600 animate-in fade-in slide-in-from-top-1 duration-200 motion-reduce:animate-none">
                     <AlertTriangle className="h-4 w-4" />
                     Caps Lock is on
                   </div>
@@ -268,8 +287,19 @@ export default function LoginPage() {
               </div>
             </CardContent>
             <CardFooter className="flex flex-col space-y-4">
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Signing in…' : 'Sign In'}
+              <Button
+                type="submit"
+                className="h-11 w-full text-base shadow-lg shadow-primary/25 transition-all duration-200 hover:shadow-xl hover:shadow-primary/35 hover:brightness-110 active:scale-[0.98] motion-reduce:transition-none"
+                disabled={loading}
+              >
+                {loading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                    Signing in…
+                  </>
+                ) : (
+                  'Sign In'
+                )}
               </Button>
               <div className="flex flex-col gap-2 text-sm text-center text-muted-foreground">
                 <button

--- a/components/ui/changelog-dialog.tsx
+++ b/components/ui/changelog-dialog.tsx
@@ -167,12 +167,12 @@ export function ChangelogDialog() {
         <Button
           variant="ghost"
           size="icon"
-          className="relative h-9 w-9 rounded-full text-white hover:bg-white/10 hover:text-white"
+          className="relative h-11 w-11 rounded-full text-white hover:bg-white/10 hover:text-white"
           title={hasUnread ? `${unreadCount} new update${unreadCount > 1 ? 's' : ''}` : 'View changelog'}
         >
           <Bell className="h-5 w-5 text-white" />
           {hasUnread && (
-            <span className="absolute -top-1 -right-1 h-5 w-5 rounded-full bg-red-600 text-white text-xs font-bold flex items-center justify-center animate-pulse">
+            <span className="absolute top-0.5 right-0.5 h-5 w-5 rounded-full bg-red-600 text-white text-xs font-bold flex items-center justify-center animate-pulse">
               {unreadCount > 9 ? '9+' : unreadCount}
             </span>
           )}

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -12,7 +12,7 @@ export function ThemeToggle() {
       variant="ghost"
       size="icon"
       onClick={() => setTheme(theme === "light" ? "dark" : "light")}
-      className="rounded-full text-white hover:bg-white/10 hover:text-white"
+      className="h-11 w-11 rounded-full text-white hover:bg-white/10 hover:text-white"
     >
       <svg
         className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -128,10 +128,20 @@ const config: Config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        float: {
+          "0%, 100%": { transform: "translate(0, 0) scale(1)" },
+          "50%": { transform: "translate(12px, -24px) scale(1.06)" },
+        },
+        "gradient-pan": {
+          "0%, 100%": { backgroundPosition: "0% 50%" },
+          "50%": { backgroundPosition: "100% 50%" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        float: "float 10s ease-in-out infinite",
+        "gradient-pan": "gradient-pan 14s ease infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary

Three areas of UI/UX improvements across the app:

### Schedule page feedback
- **Optimistic updates**: signing up, removing yourself, and admin assignments now appear on the schedule instantly, and roll back with an error toast if the save fails (previously nothing changed until the server round-trip completed)
- **Month-change loading**: switching month/year now shows the loading skeleton instead of leaving the previous month's data frozen on screen
- **Honest error state**: a failed schedule load now shows an error card with a cause-specific message and a retry button, instead of silently rendering a blank generated schedule that hides existing sign-ups; pull-to-refresh also reports failures
- Fixed a double-toast on failed saves

### Navbar redesign
- Cleanly contained brand logo (replaces the absolutely-positioned overflow hack), linked to the dashboard, enlarged on mobile
- Desktop links are rounded pills with smooth hover/active states, built on shadcn `Button`
- Account menu trigger is now an initials avatar + name + chevron; dropdown shows name and email, destructive-styled logout
- Mobile menu rebuilt from a single mapped list: icons, 44–48px touch targets, slide-down animation, user info footer, proper `aria-expanded`/`aria-controls`
- Translucent backdrop-blur bar, slimmer on mobile
- **Bug fixes**: "Dashboard" no longer stays highlighted on every sub-page (exact-match active state); nav text no longer flips dark blue in light theme (Tailwind can't apply opacity modifiers to CSS-variable colors, so the classes silently never generated — replaced with literal white shades)

### Animated login landing page
- Staggered fade/slide entrance for the brand panel content and sign-in card
- Slow-panning gradient on the brand panel plus drifting glow blobs (new `float` / `gradient-pan` keyframes)
- Glassy form card with backdrop blur; Sign In button gains a loading spinner, glow shadow, and press micro-interaction
- All animations suppressed under `prefers-reduced-motion`; CSS-only, no new dependencies

## Testing
- `npm run lint` passes (two pre-existing warnings unrelated to these changes)
- `npx tsc --noEmit` passes clean
- `next build` could not be verified in the sandbox (no network access to Google Fonts at build time), unrelated to these changes

https://claude.ai/code/session_01STwjbesEyTww66RLx6iAsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01STwjbesEyTww66RLx6iAsz)_