### PR TITLE
Date-based pay rates, admin capacity override, and schedule audit trail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,38 @@ To ensure code quality, run the following commands before committing:
 - `npm run lint` - Check for linting issues
 - `npm run typecheck` - Check for TypeScript type errors
 
+## [2026-06-20] - Date-Based Pay Rates (WMATA July 2026 Increase)
+
+### Problem Identified
+WMATA shift pay rates increased effective July 2026. PDFs for June 2026 and
+earlier must keep the legacy rates, while July 2026 and onward use the new
+rates. Previously the rates were hardcoded, so changing them would have
+incorrectly re-priced past months.
+
+### Solution Implemented
+1. **Added `getPayRateConfig(year, month)`** in `lib/utils.ts`
+   - Returns the rate set that applies to a schedule period.
+   - New (current) rates take effect July 2026 (month index 6); June 2026 and
+     earlier use the legacy rates.
+   - Legacy: $65/hr Sgt.+ / $60/hr below Sgt., $10/hr billable service charge.
+   - Current: $105/hr Sgt.+ / $75/hr below Sgt., $5/hr billable service charge.
+
+2. **Made `calculateOfficerPayRate(rank, config)` config-driven**
+   - The base rate is now resolved from the passed `PayRateConfig` rather than
+     hardcoded constants.
+
+3. **Threaded the config through both PDFs** in `app/dashboard/schedule/page.tsx`
+   - `generatePDF` and `generateBillablePDF` compute the config from the
+     exported schedule's `selectedYear`/`selectedMonth`.
+   - The billable service charge now uses `rateConfig.serviceCharge` instead of
+     a hardcoded `+ 5`.
+   - The "Pay Rates" footer note is now dynamic, and a billable rate note
+     (including the service charge) was added to the billable PDF.
+
+### Files Modified
+- `lib/utils.ts`
+- `app/dashboard/schedule/page.tsx`
+
 ## [2025-10-23] - Billable PDF Duplicate Officer Fix
 
 ### Problem Identified

--- a/app/dashboard/schedule/page.tsx
+++ b/app/dashboard/schedule/page.tsx
@@ -15,7 +15,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import { Download, Trash2, Plus, Calendar, DollarSign, FileText, AlertCircle, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
-import { formatOfficerName, formatOfficerNameForDisplay, extractRankFromOfficerName, calculateOfficerPayRate, cn } from '@/lib/utils';
+import { formatOfficerName, formatOfficerNameForDisplay, extractRankFromOfficerName, calculateOfficerPayRate, getPayRateConfig, cn } from '@/lib/utils';
 import { ScheduleSkeleton } from '@/components/schedule/schedule-skeleton';
 import { usePullToRefresh } from '@/hooks/use-pull-to-refresh';
 import {
@@ -1184,6 +1184,9 @@ export default function SchedulePage() {
 
       const doc = new jsPDF();
 
+      // Pay rates depend on the schedule's month/year (rates increased July 2026)
+      const rateConfig = getPayRateConfig(selectedYear, selectedMonth);
+
       // Add logo
       const logoImg = new Image();
       logoImg.src = '/logo-cool.png';
@@ -1277,7 +1280,7 @@ export default function SchedulePage() {
 
             // Calculate payment
             const rank = extractRankFromOfficerName(officer.name);
-            const rate = calculateOfficerPayRate(rank);
+            const rate = calculateOfficerPayRate(rank, rateConfig);
 
             if (!officerPayments[normalizedKey]) {
               officerPayments[normalizedKey] = {
@@ -1315,7 +1318,7 @@ export default function SchedulePage() {
 
             // Calculate payment
             const rank = extractRankFromOfficerName(officer.name);
-            const rate = calculateOfficerPayRate(rank);
+            const rate = calculateOfficerPayRate(rank, rateConfig);
 
             if (!officerPayments[normalizedKey]) {
               officerPayments[normalizedKey] = {
@@ -1460,7 +1463,7 @@ export default function SchedulePage() {
       doc.setFontSize(9);
       doc.setFont('helvetica', 'italic');
       doc.setTextColor(100, 100, 100);
-      doc.text('Pay Rates: Sgt. and above = $105/hr | Below Sgt. = $75/hr', 20, paymentTableY + 10);
+      doc.text(`Pay Rates: Sgt. and above = $${rateConfig.commandRate}/hr | Below Sgt. = $${rateConfig.officerRate}/hr`, 20, paymentTableY + 10);
 
       // Reset text color
       doc.setTextColor(0, 0, 0);
@@ -1488,6 +1491,9 @@ export default function SchedulePage() {
       const autoTable = (await import('jspdf-autotable')).default;
 
       const doc = new jsPDF();
+
+      // Pay rates depend on the schedule's month/year (rates increased July 2026)
+      const rateConfig = getPayRateConfig(selectedYear, selectedMonth);
 
       // Add logo
       const logoImg = new Image();
@@ -1584,8 +1590,8 @@ export default function SchedulePage() {
 
             // Calculate payment with service charge
             const rank = extractRankFromOfficerName(officer.name);
-            const baseRate = calculateOfficerPayRate(rank);
-            const billableRate = baseRate + 5; // Add $5/hour service charge
+            const baseRate = calculateOfficerPayRate(rank, rateConfig);
+            const billableRate = baseRate + rateConfig.serviceCharge; // Add per-hour service charge
 
             if (!officerPayments[normalizedKey]) {
               officerPayments[normalizedKey] = {
@@ -1626,8 +1632,8 @@ export default function SchedulePage() {
 
             // Calculate payment with service charge
             const rank = extractRankFromOfficerName(officer.name);
-            const baseRate = calculateOfficerPayRate(rank);
-            const billableRate = baseRate + 5; // Add $5/hour service charge
+            const baseRate = calculateOfficerPayRate(rank, rateConfig);
+            const billableRate = baseRate + rateConfig.serviceCharge; // Add per-hour service charge
 
             if (!officerPayments[normalizedKey]) {
               officerPayments[normalizedKey] = {
@@ -1773,6 +1779,17 @@ export default function SchedulePage() {
       doc.setFontSize(12);
       doc.setFont('helvetica', 'bold');
       doc.text(`TOTAL BILLABLE AMOUNT: $${billableGrandTotal.toFixed(2)}`, 20, paymentTableY + 15);
+
+      // Billable rate note (base rates + service charge)
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'italic');
+      doc.setTextColor(100, 100, 100);
+      doc.text(
+        `Billable Rates (incl. $${rateConfig.serviceCharge}/hr service charge): Sgt. and above = $${rateConfig.commandRate + rateConfig.serviceCharge}/hr | Below Sgt. = $${rateConfig.officerRate + rateConfig.serviceCharge}/hr`,
+        20,
+        paymentTableY + 25
+      );
+      doc.setTextColor(0, 0, 0);
 
       doc.save(`metro-schedule-billable-${monthNames[selectedMonth].toLowerCase()}-${selectedYear}.pdf`);
       toast.dismiss(toastId);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -117,13 +117,55 @@ export function extractRankFromOfficerName(officerName: string): string | null {
   return null;
 }
 
-export function calculateOfficerPayRate(rank: string | null): number {
-  if (!rank) return 75; // Default to officer rate if rank unknown
+/**
+ * Pay rates for a given period. WMATA rates increased effective July 2026, so
+ * the rates used for any PDF depend on the month/year of the schedule being
+ * exported (not on today's date).
+ */
+export interface PayRateConfig {
+  /** Hourly rate for ranks below Sergeant (and unknown ranks). */
+  officerRate: number;
+  /** Hourly rate for Sergeant and above (command staff). */
+  commandRate: number;
+  /** Per-hour service charge added on top of the base rate for billable PDFs. */
+  serviceCharge: number;
+}
+
+// Rates in effect July 2026 and onward.
+const CURRENT_PAY_RATES: PayRateConfig = {
+  officerRate: 75,
+  commandRate: 105,
+  serviceCharge: 5,
+};
+
+// Legacy rates in effect through June 2026.
+const LEGACY_PAY_RATES: PayRateConfig = {
+  officerRate: 60,
+  commandRate: 65,
+  serviceCharge: 10,
+};
+
+/**
+ * Returns the pay rate configuration that applies to a given schedule period.
+ * The new (higher) WMATA rates take effect July 2026; June 2026 and earlier use
+ * the legacy rates.
+ *
+ * @param year  Full year of the schedule (e.g. 2026).
+ * @param month Zero-indexed month (0 = January, 5 = June, 6 = July).
+ */
+export function getPayRateConfig(year: number, month: number): PayRateConfig {
+  const usesCurrentRates = year > 2026 || (year === 2026 && month >= 6);
+  return usesCurrentRates ? CURRENT_PAY_RATES : LEGACY_PAY_RATES;
+}
+
+export function calculateOfficerPayRate(rank: string | null, config: PayRateConfig): number {
+  if (!rank) return config.officerRate; // Default to officer rate if rank unknown
 
   // Normalize rank for comparison
   const normalizedRank = rank.toLowerCase().trim();
 
-  // Command staff (Sergeant and above) bill at $105/hour; everyone else $75/hour.
+  // Command staff (Sergeant and above) bill at the command rate; everyone else
+  // bills at the officer rate.
   const commandStaffRanks = [
     'chief',
     'asst. chief',
@@ -141,5 +183,5 @@ export function calculateOfficerPayRate(rank: string | null): number {
     normalizedRank.includes(commandRank)
   );
 
-  return isCommandStaff ? 105 : 75;
+  return isCommandStaff ? config.commandRate : config.officerRate;
 }


### PR DESCRIPTION
## Summary

Three changes in this PR:

1. **Date-based pay rates** — PDFs price by the exported schedule's month/year (WMATA increase effective July 2026).
2. **Admin capacity override** — admins can add a 3rd officer on Tue–Thu shifts (hard ceiling of 3/hr).
3. **Schedule audit trail** — time-stamped record of every sign-up, removal, and hours change, viewable by admins.

---

## 1. Date-based pay rates

| Period | Sgt. & above | Below Sgt. | Service charge |
|---|---|---|---|
| **June 2026 & earlier** (legacy) | $65/hr | $60/hr | $10/hr |
| **July 2026 onward** (new) | $105/hr | $75/hr | $5/hr |

- Added `PayRateConfig` + `getPayRateConfig(year, month)` in `lib/utils.ts`; `calculateOfficerPayRate(rank, config)` is now config-driven.
- `generatePDF` / `generateBillablePDF` derive the config from `selectedYear`/`selectedMonth`; rate footers are dynamic and the billable PDF now shows its rates (base + service charge).

## 2. Admin capacity override

- `getEffectiveMaxOfficersPerHour(slotDate, isAdmin)` in `lib/schedule-utils.ts`: admins may exceed the standard limit (2 on Tue–Thu) up to `ADMIN_OVERRIDE_MAX_OFFICERS_PER_HOUR` (3). Regular officers keep the standard limit.
- Server validation (`lib/schedule-validation.ts`) now rejects only **newly introduced** violations, so a previously granted override doesn't block unrelated later changes to the same shift — but regular officers still can't join an hour already at/over the standard limit.
- Client checks in the schedule page use the effective limit, so admins see and can assign the 3rd slot.

## 3. Schedule audit trail

- `lib/schedule-audit.ts` diffs every save into `signup` / `removal` / `hours_change` entries with timestamp, actor (name, ID, role), affected officer, shift date/slot/hours, self-vs-admin flag, and a `capacityOverride` flag when the change exceeded the standard limit.
- Entries persist to the server-only `scheduleAudit` Firestore collection after each successful save (best-effort: audit failures are logged, never fail the save). The existing catch-all Firestore rule denies all client access.
- New admin-only API `GET /api/admin/audit?month=&year=` (queries by a single `monthKey` field — no composite index needed).
- New page `/dashboard/admin/audit` with month navigation, officer/admin name filter, and action/override badges; linked from Admin Tools. The log covers changes made after this feature is deployed.

## Verification

- `npx tsc --noEmit` → clean; `npm run lint` → 0 errors (2 pre-existing warnings, unrelated).
- Scripted checks against the real validation/audit code, all passing:
  - Regular officer as 3rd on a Wednesday → rejected (max 2).
  - Admin adds 3rd on Wednesday → allowed; 4th → rejected (ceiling 3).
  - After an override, unrelated sign-up in free hours → allowed; joining the over-capacity hours → rejected.
  - Audit entries produced correctly for admin signup (with `capacityOverride: true`), admin removal, and self sign-up (`selfAction: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KguHKDig1ZKsBQJH3rysVC